### PR TITLE
fix nogui build

### DIFF
--- a/client/gui-nogui.go
+++ b/client/gui-nogui.go
@@ -7,6 +7,7 @@ import "io"
 const haveGUI = false
 
 type noGUIClient struct {
+	client
 	dev bool
 }
 


### PR DESCRIPTION
30b1f168 broke the nogui build:

```
$ go build -tags nogui
# github.com/agl/pond/client
./main_linux.go:68: client.disableV2Ratchet undefined (type *noGUIClient has no field or method disableV2Ratchet)
```
