### PR TITLE
Modified the osx instructions

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -106,15 +106,27 @@ $GOPATH/bin/client
 <p>It's possible to get Pond building on OS X after spending <i>lots</i> of time with homebrew. Something that's known to have worked,</p>
 
 <pre>
-// you'll need an X server running in order to launch Pond unless you
+// You will require xquartz to run Pond. If you do not already have it installed, you can find it at http://xquartz.macosforge.org/
+
+// You will require tor to run Pond. If you do not already have it, you can get it from https://www.torproject.org/download/download.html.en
+// Running the tor browser bundle is enough.
+
+// These instructions assume the use of the Homebrew package manager for OSX. If you are already using macports or fink (competing package managers), you may not be able to follow these instructions. If you are not using any of these and need to install homebrew, you can find the instructions on doing so at http://brew.sh/
+
+// Install prerequisites for running Pond
+brew install go gtk+3 gtkspell3 mercurial
+
+// Edit your gtk settings to enable the use of xquartz for the pond gui
 brew edit gtk+3
 // then add --enable-quartz-backend to the configure arguments
-brew install go gtk+3 gtkspell3
 
+// Add your go environment variable settings
 export GOPATH=$HOME/gopkg
 export PATH=$PATH:$GOPATH/bin
 export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+// You need to also add these to your ~/.profile file if you want to run pond again after reboot, unless you want to manually apply the settings each time you run pond.
 
+// Finally, install pond:
 go get github.com/agl/pond/client
 // now `client` should be in your path
 </pre>


### PR DESCRIPTION
Among the other issues discovered when installing pond using the osx
instructions: the gtk+3 config settings for xquartz have to be applied _after_ installing
gtk+3 or you will get errors.
