### PR TITLE
add external command hook POND_HOOK_RECEIVE

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -211,6 +211,9 @@ type client struct {
 	// disableV2Ratchet causes the client to advertise and process V1
 	// axolotl ratchet support.
 	disableV2Ratchet bool
+
+	// command to run upon receiving messages
+	receiveHookCommand string
 }
 
 // UI abstracts behaviour that is specific to a given interface (GUI or CLI).
@@ -680,6 +683,8 @@ func (c *client) loadUI() error {
 			return err
 		}
 	}
+
+	c.receiveHookCommand = os.Getenv("POND_HOOK_RECEIVE")
 
 	c.ui.loadingUI()
 

--- a/client/network.go
+++ b/client/network.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -431,6 +432,15 @@ NextCandidate:
 	c.inbox = append(c.inbox, inboxMsg)
 	c.ui.processFetch(inboxMsg)
 	c.save()
+
+	if c.receiveHookCommand != "" {
+		cmd := exec.Command(c.receiveHookCommand)
+		go func() {
+			if err := cmd.Run(); err != nil {
+				c.log.Errorf("Failed to run receive hook command: %s", err.Error())
+			}
+		}()
+	}
 }
 
 func (c *client) processServerAnnounce(m NewMessage) {


### PR DESCRIPTION
Perhaps other command hooks should be added. This feels out of place in
network.go.
