### PR TITLE
cli: swap order of inbox and outbox in status

### DIFF
--- a/client/cli.go
+++ b/client/cli.go
@@ -755,8 +755,8 @@ func (tab cliTable) WriteToWithWidths(w io.Writer, widths []int) {
 func (c *cliClient) showState() {
 	tables := make([]cliTable, 0, 4)
 
-	tables = append(tables, c.inboxSummary())
 	tables = append(tables, c.outboxSummary())
+	tables = append(tables, c.inboxSummary())
 	tables = append(tables, c.draftsSummary())
 	tables = append(tables, c.contactsSummary())
 


### PR DESCRIPTION
I want to see the inbox more often than the outbox, and a long outbox causes me
to have to scroll up to see the inbox if the inbox is displayed first.
