### PR TITLE
Avoid SafeTempDir with odd permissions.

### DIFF
--- a/client/system/sys_linux.go
+++ b/client/system/sys_linux.go
@@ -85,7 +85,7 @@ func findSafeTempDir() {
 		path := fields[1]
 		filesystem := fields[2]
 		if filesystem == "tmpfs" &&
-			syscall.Access(path, 2 /* write ok */) == nil {
+			syscall.Access(path, 7 /* rwx ok */) == nil {
 			candidates = append(candidates, path)
 		}
 


### PR DESCRIPTION
We actually need rwx permissions, so check for it.
