### PR TITLE
Add a warning in documentation about using golang 1.0

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -58,6 +58,9 @@ $GOPATH/bin/client</pre>
 
 <p>Same as Ubuntu, above, but 1) on the <tt>go get</tt> command line add <tt>-tags ubuntu</tt> before the URL and 2) the gtkspell package is called <tt>libgtkspell-3-dev</tt>. On more recent versions of Debian, the instructions should be exactly the same as Ubuntu.</p>
 
+<p><i>WARNING</i>:Using <tt>golang</tt> version 1.0 (Wheezy package) is not recommended and compatibility is untested. If you face any problems compiling pond
+try to upgrade <tt>golang</tt> to version 1.2 from the testing repository.</p>
+
 <h5>Tails</h5>
 <p>Tails only supports the CLI mode of operation for Pond as it is based on an old Debian-stable.
 Build, install and usage instructions for Tails users:</p>


### PR DESCRIPTION
Just a small warning for Debian Wheezy users.
