### PR TITLE
Fix editstate build.

### DIFF
--- a/editstate/editstate.go
+++ b/editstate/editstate.go
@@ -528,7 +528,11 @@ func do() bool {
 	states := make(chan disk.NewState)
 	done := make(chan struct{})
 	go stateFile.StartWriter(states, done)
-	states <- disk.NewState{newStateSerialized, false}
+	states <- disk.NewState{
+		State:                newStateSerialized,
+		RotateErasureStorage: false,
+		Destruct:             false,
+	}
 	close(states)
 	<-done
 


### PR DESCRIPTION
637bac76 added Destruct to disk.NewState.

This is the same as #74 which shows up as merged, but for some reason didn't end up in the repo.
