### PR TITLE
Added reply quoting to the GUI.

### DIFF
--- a/client/ratchet/ratchet.go
+++ b/client/ratchet/ratchet.go
@@ -32,7 +32,7 @@ const (
 	nonceInHeaderOffset = 4 + 4 + 32
 	// maxMissingMessages is the maximum number of missing messages that
 	// we'll keep track of.
-	maxMissingMessages = 2048
+	maxMissingMessages = 8
 )
 
 // Ratchet contains the per-contact, crypto state.
@@ -330,9 +330,9 @@ func (r *Ratchet) trySavedKeys(ciphertext []byte) ([]byte, error) {
 // saveKeys takes a header key, the current chain key, a received message
 // number and the expected message number and advances the chain key as needed.
 // It returns the message key for given given message number and the new chain
-// key. If any messages have been skipped over, it also returns savedKey, a map
-// suitable for merging with r.saved, that contains the message keys for the
-// missing messages.
+// key. If any messages have been skipped over, it also returns savedKeys, a
+// map suitable for merging with r.saved, that contains the message keys for
+// the missing messages.
 func (r *Ratchet) saveKeys(headerKey, recvChainKey *[32]byte, messageNum, receivedCount uint32) (provisionalChainKey, messageKey [32]byte, savedKeys map[[32]byte]map[uint32]savedKey, err error) {
 	if messageNum < receivedCount {
 		// This is a message from the past, but we didn't have a saved

--- a/panda/appengine.go
+++ b/panda/appengine.go
@@ -87,6 +87,10 @@ func (hmp *HTTPMeetingPlace) attemptExchange(log func(string, ...interface{}), i
 
 	response, err := http.ReadResponse(bufio.NewReader(conn), request)
 
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var responseBody []byte
 	if response.Body != nil {
 		r := &io.LimitedReader{R: response.Body, N: payloadBytes + 1}


### PR DESCRIPTION
Ideally this should quote only the selected text if any text is selected in the message viewer when the user presses reply.  At least that's how my email client works.

I assume Go initializes the two local variables I eliminated to zero, but I thought it looked cleaner to initialize them explicitly and and set them if inReplyTo is set.  <shrug>
