### PR TITLE
cli: print sendCommand errors instead of logging

### DIFF
--- a/client/cli.go
+++ b/client/cli.go
@@ -1253,7 +1253,7 @@ Handle:
 		}
 		id, _, err := c.sendDraft(draft)
 		if err != nil {
-			c.log.Errorf("%s Error sending: %s\n", termErrPrefix, err)
+			c.Printf("%s Error sending: %s\n", termErrPrefix, err)
 			return
 		}
 		if draft.inReplyTo != 0 {


### PR DESCRIPTION
This makes it obvious that a too-large message has not been sent after running the send command.
