### PR TITLE
tpm-tools is required to use TPM

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -47,7 +47,7 @@ title: Pond
 
 <h5>Ubuntu 13.10</h5>
 
-<pre>sudo apt-get install golang git libgtk-3-dev libgtkspell3-3-dev libtspi-dev trousers tor mercurial
+<pre>sudo apt-get install golang git libgtk-3-dev libgtkspell3-3-dev libtspi-dev trousers tor mercurial tpm-tools
 cd
 mkdir gopkg
 export GOPATH=$HOME/gopkg


### PR DESCRIPTION
At least for Ubuntu.  Have written up a [fairly thorough guide to enabling TPM](https://gist.github.com/glamrock/9923454) for use with Pond, but need to polish it more before adding it.
