### PR TITLE
corrected spelling for the Entomb button in GUI

### DIFF
--- a/client/gui.go
+++ b/client/gui.go
@@ -1920,7 +1920,7 @@ func (c *guiClient) identityUI() interface{} {
 									name:        "entomb",
 									insensitive: true,
 								},
-								text: "Emtomb",
+								text: "Entomb",
 							}},
 							{1, 1, Label{
 								widgetBase: widgetBase{hExpand: true},


### PR DESCRIPTION
Was misspelled as "Emtomb" in gui.go
