### PR TITLE
bshow next transaction time when sending message

### DIFF
--- a/client/cli.go
+++ b/client/cli.go
@@ -1343,7 +1343,9 @@ Handle:
 				if msg.cliId == invalidCliId {
 					msg.cliId = c.newCliId()
 				}
-				c.Printf("%s Created new outbox entry %s%s%s\n", termInfoPrefix, termCliIdStart, msg.cliId.String(), termReset)
+				nextTransaction :=  c.nextTransactionTime.Sub(c.Now())/time.Second*time.Second
+				c.Printf("%s (%s) Created new outbox entry %s%s%s, next transaction in %s\n", termInfoPrefix, c.Now().Format(shortTimeFormat), termCliIdStart, msg.cliId.String(), termReset, nextTransaction)
+
 				c.setCurrentObject(msg)
 				c.showQueueState()
 				break

--- a/client/client.go
+++ b/client/client.go
@@ -213,6 +213,9 @@ type client struct {
 	// disableV2Ratchet causes the client to advertise and process V1
 	// axolotl ratchet support.
 	disableV2Ratchet bool
+
+	// nextTransactionTime stores the absolute time of the next transaction
+	nextTransactionTime time.Time
 }
 
 // UI abstracts behaviour that is specific to a given interface (GUI or CLI).

--- a/client/network.go
+++ b/client/network.go
@@ -870,7 +870,9 @@ func (c *client) transact() {
 					delaySeconds = 5
 				}
 				delay := time.Duration(delaySeconds*1000) * time.Millisecond
-				c.log.Printf("Next network transaction in %s seconds", delay)
+				c.nextTransactionTime = c.Now().Add(delay)
+				c.log.Printf("Next network transaction in %s", (delay/time.Second*time.Second))
+
 				timerChan = time.After(delay)
 			}
 


### PR DESCRIPTION
- add nextTransactionTime variable to the client to store the next transaction absolute time
- show when next transaction will happen in the "Created new outbox..." message
- remove second decimals from "Next network transaction..." log message
