### PR TITLE
moveContactsMessagesToEndOfQueue if server is down

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1151,6 +1151,10 @@ func (c *client) removeQueuedMessage(index int) {
 	c.queue = newQueue
 }
 
+// If sending a message fails for any reason then we want to move the
+// message to the end of the queue so that we never clog the queue with
+// an unsendable message. However, we also don't want to reorder messages 
+// so all messages to the same contact are moved to the end of the queue.
 func (c *client) moveContactsMessagesToEndOfQueue(id uint64) {
 	// c.queueMutex must be held before calling this function.
 


### PR DESCRIPTION
We must call moveContactsMessagesToEndOfQueue if we encounter trouble contacting a pond server while sending.  Fixes https://github.com/agl/pond/issues/155 

I moved the comment describing what moveContactsMessagesToEndOfQueue does to the function itself since it's now called in two places.  