### PR TITLE
make tests work without GTK

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -402,13 +402,16 @@ func TestAccountCreation(t *testing.T) {
 		entries: map[string]string{"pw": ""},
 	}
 
-	client.gui.WaitForSignal()
-	if id := client.gui.currentStateID; id != uiStateErasureStorage {
-		t.Fatalf("client in UI state %d when it was expected to be setting up erasure storage", id)
-	}
+	if client.hasErasure() {
 
-	client.gui.events <- Click{
-		name: "continue",
+		client.gui.WaitForSignal()
+		if id := client.gui.currentStateID; id != uiStateErasureStorage {
+			t.Fatalf("client in UI state %d when it was expected to be setting up erasure storage", id)
+		}
+
+		client.gui.events <- Click{
+			name: "continue",
+		}
 	}
 
 	client.gui.WaitForSignal()
@@ -458,10 +461,14 @@ func proceedToMainUI(t *testing.T, client *TestClient, server *TestServer) {
 		name:    "next",
 		entries: map[string]string{"pw": ""},
 	}
-	client.AdvanceTo(uiStateErasureStorage)
-	client.gui.events <- Click{
-		name: "continue",
+
+	if client.hasErasure() {
+		client.AdvanceTo(uiStateErasureStorage)
+		client.gui.events <- Click{
+			name: "continue",
+		}
 	}
+
 	client.AdvanceTo(uiStateCreateAccount)
 	url := server.URL()
 	client.gui.events <- Click{
@@ -2357,9 +2364,12 @@ func TestEntombing(t *testing.T) {
 		name:    "next",
 		entries: map[string]string{"pw": ""},
 	}
-	client1.AdvanceTo(uiStateErasureStorage)
-	client1.gui.events <- Click{
-		name: "continue",
+
+	if client1.hasErasure() {
+		client1.AdvanceTo(uiStateErasureStorage)
+		client1.gui.events <- Click{
+			name: "continue",
+		}
 	}
 
 	client1.AdvanceTo(uiStateCreateAccount)

--- a/client/erasure_darwin.go
+++ b/client/erasure_darwin.go
@@ -8,3 +8,5 @@ func (c *client) createErasureStorage(pw string, stateFile *disk.StateFile) erro
 	// No NVRAM support on OS X yet.
 	return stateFile.Create(pw)
 }
+
+func (c *client) hasErasure() bool { return false }

--- a/client/erasure_freebsd.go
+++ b/client/erasure_freebsd.go
@@ -8,3 +8,5 @@ func (c *client) createErasureStorage(pw string, stateFile *disk.StateFile) erro
 	// No NVRAM support on FreeBSD yet.
 	return stateFile.Create(pw)
 }
+
+func (c *client) hasErasure() bool { return false }

--- a/client/erasure_notpm.go
+++ b/client/erasure_notpm.go
@@ -9,3 +9,5 @@ import (
 func (c *client) createErasureStorage(pw string, stateFile *disk.StateFile) error {
 	return stateFile.Create(pw)
 }
+
+func (c *client) hasErasure() bool { return false }

--- a/client/gtk.go
+++ b/client/gtk.go
@@ -1,4 +1,4 @@
-// +build !nogui
+// +build !nogui,!nogtk
 
 package main
 

--- a/client/nogtk.go
+++ b/client/nogtk.go
@@ -1,0 +1,23 @@
+// +build nogtk
+
+package main
+
+type GTKUI struct{}
+
+func NewGTKUI() *GTKUI { return &GTKUI{} }
+
+func (ui *GTKUI) Run() {
+	panic("not implemented")
+}
+
+func (ui *GTKUI) Actions() chan<- interface{} {
+	panic("not implemented")
+}
+
+func (ui *GTKUI) Events() <-chan interface{} {
+	panic("not implemented")
+}
+
+func (ui *GTKUI) Signal() {
+	panic("not implemented")
+}


### PR DESCRIPTION
Turns out there wasn't much to do. I skipped a step in the test logic when there's no erasure storage and added a build tag so you can build the abstract gui without trying to build gtk. Added a new flag nogtk, stubbed out the GTKUI interface so the mains don't need to be modified.

```
bens-MacBook-Pro:client ben$ go test -tags nogtk
PASS
ok  	github.com/bnagy/pond/client	46.853s
```