### PR TITLE
doc/index.html: update/fix Tails instructions

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -45,7 +45,9 @@ $GOPATH/bin/client</pre>
 
 <p>Same as Ubuntu, above, but 1) on the <tt>go get</tt> command line add <tt>-tags ubuntu</tt> before the URL and 2) the gtkspell package is called <tt>libgtkspell-3-dev</tt>. On more recent versions of Debian, the instructions should be exactly the same as Ubuntu.</p>
 
-<h5>Tails (Version 1.1.1)</h5>
+<h5>Tails</h5>
+
+<em>These instructions have been tested on Tails 1.3. You should always use the latest version of Tails.</em>
 
 <p>First, if you have not done so already, configure Tails persistence (<em>Applications</em> &rarr; <em>Tails</em> &rarr; <em>Configure persistent volume</em>) to persist "Personal Data", "APT Packages", "APT Lists", and "Dotfiles". A reboot is required after these settings are changed.</p>
 
@@ -56,11 +58,11 @@ $GOPATH/bin/client</pre>
 <pre>echo 'export GOPATH=$HOME/Persistent/go/' &gt;&gt; ~/.bashrc
 . ~/.bashrc
 mkdir $GOPATH
-alias pond-build='sudo bash -c "sudo apt-get update &amp;&amp; \
-apt-get install -y -t testing golang &amp;&amp; \
-apt-get install -y gcc git mercurial libgtk-3-dev libgtkspell-3-dev libtspi-dev trousers" &amp;&amp; \
-go get -u -tags ubuntu github.com/agl/pond/client &amp;&amp; \
-echo "Success." || echo "Sorry, something went wrong."'
+alias pond-build='sudo bash -c "sudo apt-get update &amp;&amp; '\
+'apt-get install -y -t testing golang &amp;&amp; '\
+'apt-get install -y gcc git mercurial libgtk-3-dev libgtkspell-3-dev libtspi-dev trousers" &amp;&amp; '\
+'go get -u -tags ubuntu github.com/agl/pond/client &amp;&amp; '\
+'echo "Success." || echo "Sorry, something went wrong."'
 alias pond-install-deps='sudo apt-get install libtspi1 libgtkspell-3-0'
 alias pond='$GOPATH/bin/client'
 alias pond-cli='$GOPATH/bin/client --cli'


### PR DESCRIPTION
I just tested on Tails 1.3 and found that while the instructions result in a
working Pond (with GUI) they also result in a .bashrc that prints these two
errors in every new shell:

    unexpected EOF while looking for matching `''
    syntax error: unexpected end of file

One of the aliases (pond) was still set, but the others (pond-build, pond-cli,
pond-install-deps) are not set. I'm not sure how this could've happened as I do
remember testing the .bashrc before. Anyway, this commit fixes the instructions
so that the aliases get saved properly.